### PR TITLE
Fix revisions list not updating after Undo

### DIFF
--- a/resources/views/revision_timeline.blade.php
+++ b/resources/views/revision_timeline.blade.php
@@ -1,11 +1,12 @@
 
+<div id="timeline">
 @foreach($revisions as $revisionDate => $dateRevisions)
       <h5 class="text-primary">
         {{ Carbon\Carbon::parse($revisionDate)->isoFormat(config('backpack.base.default_date_format')) }}
       </h5>
 
   @foreach($dateRevisions as $history)
-    <div class="card">
+    <div class="card timeline-item-wrap">
 
       @if($history->key == 'created_at' && !$history->old_value)
         <div class="card-header">
@@ -38,6 +39,7 @@
     </div>
   @endforeach
 @endforeach
+</div>
 
 @section('after_scripts')
   <script type="text/javascript">
@@ -59,13 +61,22 @@
         },
         success: function(revisionTimeline) {
           // Replace the revision list with the updated revision list
-          $('.timeline').replaceWith(revisionTimeline);
+          $('#timeline').replaceWith(revisionTimeline);
 
           // Animate the new revision in (by sliding)
           $('.timeline-item-wrap').first().addClass('fadein');
+
+          // Show a green notification bubble
           new Noty({
               type: "success",
               text: "{{ trans('revise-operation::revise.revision_restored') }}"
+          }).show();
+        },
+        error: function(data) {
+          // Show a red notification bubble
+          new Noty({
+              type: "error",
+              text: data.responseJSON.message
           }).show();
         }
       });

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -48,7 +48,7 @@ trait ReviseOperation
 
         // add a new method on the CrudPanel object to allow this operation
         // to call getRevisionsForEntry from multiple operation methods
-        $this->crud->macro('getRevisionsForEntry', function($id) {
+        $this->crud->macro('getRevisionsForEntry', function ($id) {
             $revisions = [];
 
             // Group revisions by change date


### PR DESCRIPTION
Fixes #2 

The individual commits show more detail about the modifications:
- after Undo, the HTML is now properly updated with the new revisions;
-  `$this->crud->listRevisions($id)` did NOT exists in Backpack 4.1 and the name was too similar to `ReviseOperation::listRevisions()` (which actually lists the revisions), so I created a new method, `getRevisionsForEntry($id)`, directly on the CrudPanel object using a macro; this allows us to call this method anytime anywhere inside the Revise operation, and its name is considerably different from the controller action;