### PR TITLE
Added ability to customize views

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 All notable changes to `ReviseOperation` will be documented in this file.
 
+## Version 1.0.4 - 2020-07-22
+
+### Added
+- ability to overwrite operation views - fixes #4;
+
+## Version 1.0.3 - 2020-07-03
+
+### Fixed
+- Fix revisions list not updating after Undo @tabacitu (#3)
+
 ## Version 1.0.2 - 2020-03-27
 
 ### Fixed

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,10 @@ class CategoryCrudController extends CrudController
 
 For complex usage, head on over to [VentureCraft/revisionable](https://github.com/VentureCraft/revisionable) to see the full documentation and extra configuration options.
 
+## Customizing views
+
+If you need to change the operation views in any way, you can do so by creating a blade file with the same name in your `resources/views/vendor/backpack/revise-operation` directory. Blade files there take priority over files in the package.
+
 
 ## Change log
 

--- a/src/ReviseOperationServiceProvider.php
+++ b/src/ReviseOperationServiceProvider.php
@@ -15,7 +15,7 @@ class ReviseOperationServiceProvider extends ServiceProvider
     {
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'revise-operation');
 
-        // load views 
+        // load views
         // - from 'resources/views/vendor/backpack/revise-operation' if they're there
         // - otherwise fall back to package views
         $this->loadViewsFrom(resource_path('views/vendor/backpack/revise-operation'), 'revise-operation');

--- a/src/ReviseOperationServiceProvider.php
+++ b/src/ReviseOperationServiceProvider.php
@@ -14,6 +14,11 @@ class ReviseOperationServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'revise-operation');
+
+        // load views 
+        // - from 'resources/views/vendor/backpack/revise-operation' if they're there
+        // - otherwise fall back to package views
+        $this->loadViewsFrom(resource_path('views/vendor/backpack/revise-operation'), 'revise-operation');
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'revise-operation');
 
         // Publishing is only necessary when using the CLI.


### PR DESCRIPTION
Fixes #4 

You can now place blade files inside `resources/views/vendor/backpack/revise-operation` and they will take priority over package files.