### PR TITLE
Add support for translatable models

### DIFF
--- a/resources/views/revision_timeline.blade.php
+++ b/resources/views/revision_timeline.blade.php
@@ -41,7 +41,7 @@
                     @endif
                 </div></div>
             <div class="col-md-6"><div class="alert alert-success" style="overflow: hidden;">
-                    @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->oldValue()))
+                    @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->newValue()))
                         @foreach(json_decode($history->newValue()) as $lang=>$langValue)
                             <p>[{{$lang}}]:{{$langValue}}</p>
                         @endforeach

--- a/resources/views/revision_timeline.blade.php
+++ b/resources/views/revision_timeline.blade.php
@@ -33,8 +33,8 @@
           <div class="row">
             <div class="col-md-6"><div class="alert alert-danger" style="overflow: hidden;">
                     @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->oldValue()))
-                        @foreach(json_decode($history->oldValue()) as $lang=>$text)
-                            <p>[{{$lang}}]:{{$text}}</p>
+                        @foreach(json_decode($history->oldValue()) as $lang=>$langValue)
+                            <p>[{{$lang}}]:{{$langValue}}</p>
                         @endforeach
                     @else
                         {{$history->oldValue()   }}
@@ -42,8 +42,8 @@
                 </div></div>
             <div class="col-md-6"><div class="alert alert-success" style="overflow: hidden;">
                     @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->oldValue()))
-                        @foreach(json_decode($history->newValue()) as $lang=>$text)
-                            <p>[{{$lang}}]:{{$text}}</p>
+                        @foreach(json_decode($history->newValue()) as $lang=>$langValue)
+                            <p>[{{$lang}}]:{{$langValue}}</p>
                         @endforeach
                     @else
                         {{$history->newValue()   }}

--- a/resources/views/revision_timeline.blade.php
+++ b/resources/views/revision_timeline.blade.php
@@ -32,7 +32,7 @@
           </div>
           <div class="row">
             <div class="col-md-6"><div class="alert alert-danger" style="overflow: hidden;">
-                    @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->oldValue()))
+                    @if($entry->translationEnabled() and $entry->isTranslatableAttribute($history->key) and !empty($history->oldValue()))
                         @foreach(json_decode($history->oldValue()) as $lang=>$langValue)
                             <p>[{{$lang}}]:{{$langValue}}</p>
                         @endforeach
@@ -41,7 +41,7 @@
                     @endif
                 </div></div>
             <div class="col-md-6"><div class="alert alert-success" style="overflow: hidden;">
-                    @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->newValue()))
+                    @if($entry->translationEnabled() and $entry->isTranslatableAttribute($history->key) and !empty($history->newValue()))
                         @foreach(json_decode($history->newValue()) as $lang=>$langValue)
                             <p>[{{$lang}}]:{{$langValue}}</p>
                         @endforeach

--- a/resources/views/revision_timeline.blade.php
+++ b/resources/views/revision_timeline.blade.php
@@ -31,8 +31,24 @@
             <div class="col-md-6">{{ mb_ucfirst(trans('revise-operation::revise.to')) }}:</div>
           </div>
           <div class="row">
-            <div class="col-md-6"><div class="alert alert-danger" style="overflow: hidden;">{{ $history->oldValue() }}</div></div>
-            <div class="col-md-6"><div class="alert alert-success" style="overflow: hidden;">{{ $history->newValue() }}</div></div>
+            <div class="col-md-6"><div class="alert alert-danger" style="overflow: hidden;">
+                    @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->oldValue()))
+                        @foreach(json_decode($history->oldValue()) as $lang=>$text)
+                            <p>[{{$lang}}]:{{$text}}</p>
+                        @endforeach
+                    @else
+                        {{$history->oldValue()   }}
+                    @endif
+                </div></div>
+            <div class="col-md-6"><div class="alert alert-success" style="overflow: hidden;">
+                    @if(isset($entry->translatable) and in_array($history->key,$entry->translatable) and !empty($history->oldValue()))
+                        @foreach(json_decode($history->newValue()) as $lang=>$text)
+                            <p>[{{$lang}}]:{{$text}}</p>
+                        @endforeach
+                    @else
+                        {{$history->newValue()   }}
+                    @endif
+                </div></div>
           </div>
         </div>
       @endif

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -118,9 +118,11 @@ trait ReviseOperation
             $revision = Revision::findOrFail($revisionId);
 
             // Update the revisioned field with the old value
-            if (isset($entry->translatable) and in_array($revision->key,$entry->translatable) and !empty($revision->old_value))
-                $entry->{$revision->key}=json_decode($revision->old_value,true);
-            else $entry->{$revision->key}=$revision->old_value;
+            if (isset($entry->translatable) and in_array($revision->key, $entry->translatable) and ! empty($revision->old_value)) {
++                $entry->{$revision->key} = json_decode($revision->old_value, true);
++            } else {
++                $entry->{$revision->key} = $revision->old_value;
++            }
             $entry->save();
 
             $this->data['entry'] = $this->crud->getEntry($id);

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -118,7 +118,7 @@ trait ReviseOperation
             $revision = Revision::findOrFail($revisionId);
 
             // Update the revisioned field with the old value
-            if (isset($entry->translatable) and in_array($revision->key, $entry->translatable) and ! empty($revision->old_value)) {
+            if ($entry->translationEnabled() and $entry->isTranslatableAttribute($revision->key) and ! empty($revision->old_value)) {
                 $entry->{$revision->key} = json_decode($revision->old_value, true);
             } else {
                 $entry->{$revision->key} = $revision->old_value;

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -119,10 +119,10 @@ trait ReviseOperation
 
             // Update the revisioned field with the old value
             if (isset($entry->translatable) and in_array($revision->key, $entry->translatable) and ! empty($revision->old_value)) {
-+                $entry->{$revision->key} = json_decode($revision->old_value, true);
-+            } else {
-+                $entry->{$revision->key} = $revision->old_value;
-+            }
+                $entry->{$revision->key} = json_decode($revision->old_value, true);
+            } else {
+                $entry->{$revision->key} = $revision->old_value;
+            }
             $entry->save();
 
             $this->data['entry'] = $this->crud->getEntry($id);

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -118,7 +118,10 @@ trait ReviseOperation
             $revision = Revision::findOrFail($revisionId);
 
             // Update the revisioned field with the old value
-            $entry->update([$revision->key => $revision->old_value]);
+            if (isset($entry->translatable) and in_array($revision->key,$entry->translatable) and !empty($revision->old_value))
+                $entry->{$revision->key}=json_decode($revision->old_value,true);
+            else $entry->{$revision->key}=$revision->old_value;
+            $entry->save();
 
             $this->data['entry'] = $this->crud->getEntry($id);
             $this->data['crud'] = $this->crud;


### PR DESCRIPTION
## WHY

i have 2 problems with use translatable and revisionable models.
First:
restoreRevision function save original JSON code translatable filed as new translated data.
internal data is broken and old json is put into new json.
Second:
change history looks ugly 

### AFTER - What is happening after this PR?
Everything is fine! 
![image](https://user-images.githubusercontent.com/23197378/151690716-ec693a3a-4db6-4959-8339-32758a8069a0.png)

