### PR TITLE
fix view caching

### DIFF
--- a/src/ReviseOperationServiceProvider.php
+++ b/src/ReviseOperationServiceProvider.php
@@ -18,7 +18,9 @@ class ReviseOperationServiceProvider extends ServiceProvider
         // load views
         // - from 'resources/views/vendor/backpack/revise-operation' if they're there
         // - otherwise fall back to package views
-        $this->loadViewsFrom(resource_path('views/vendor/backpack/revise-operation'), 'revise-operation');
+        if (is_dir(resource_path('views/vendor/backpack/revise-operation'))) {
+            $this->loadViewsFrom(resource_path('views/vendor/backpack/revise-operation'), 'revise-operation');
+        }
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'revise-operation');
 
         // Publishing is only necessary when using the CLI.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

See https://github.com/Laravel-Backpack/CRUD/issues/4197

Got error when caching views.

### AFTER - What is happening after this PR?

No error when caching views.

## HOW

### How did you achieve that, in technical terms?

Checked if that directory exists, before loading the published views.


### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

`php artisan cache:views`
