### PR TITLE
[Bug]Translatable revisions

### DIFF
--- a/resources/views/revision_timeline.blade.php
+++ b/resources/views/revision_timeline.blade.php
@@ -8,12 +8,12 @@
   @foreach($dateRevisions as $history)
     <div class="card timeline-item-wrap mb-3">
 
-      @if($history->key == 'created_at' && !$history->old_value)
-        <div class="card-header">
-          <strong class="time"><i class="la la-clock"></i> {{ date('h:ia', strtotime($history->created_at)) }}</strong> -
-          {{ $history->userResponsible()?$history->userResponsible()->name:trans('revise-operation::revise.guest_user') }} {{ trans('revise-operation::revise.created_this') }} {{ $crud->entity_name }}
-        </div>
-      @else
+        @if($history->key == 'created_at' && !$history->old_value)
+            <div class="card-header">
+                <strong class="time"><i class="la la-clock"></i> {{ date('h:ia', strtotime($history->created_at)) }}</strong> -
+                {{ $history->userResponsible()?$history->userResponsible()->name:trans('revise-operation::revise.guest_user') }} {{ trans('revise-operation::revise.created_this') }} {{ $crud->entity_name }}
+            </div>
+         @else
         <div class="card-header">
           <strong class="time"><i class="la la-clock"></i> {{ date('h:ia', strtotime($history->created_at)) }}</strong> -
           {{ $history->userResponsible()?$history->userResponsible()->name:trans('revise-operation::revise.guest_user') }} {{ trans('revise-operation::revise.changed_the') }} {{ $history->fieldName() }}

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -120,10 +120,9 @@ trait ReviseOperation
 
             if (method_exists($entry, 'isTranslatableAttribute') && $entry->isTranslatableAttribute($revision->key)) {
                 $oldValueAsArray = json_decode($revision->old_value, true);
-                $entry->forgetTranslations($revision->key);
-                foreach ($oldValueAsArray as $locale => $value) {
-                    $entry->setTranslation($revision->key, $locale, $value);
-                }
+                $entry->forgetTranslation($revision->key, app()->getLocale());
+                $entry->setTranslation($revision->key, app()->getLocale(), $oldValueAsArray[app()->getLocale()] ?? null);
+                
                 $entry->save();
             } else {
                 // Update the revisioned field with the old value

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -116,12 +116,21 @@ trait ReviseOperation
             abort(500, 'Can\'t restore revision without revision_id');
         } else {
             $entry = $this->crud->getEntryWithoutFakes($id);
-            $revision = \Venturecraft\Revisionable\Revisionable::newModel()->findOrFail($revisionId);
+            $revision = Revision::findOrFail($revisionId);
+           
+            if(method_exists($entry, 'isTranslatableAttribute') && $entry->isTranslatableAttribute($revision->key)) {
+                $oldValueAsArray = json_decode($revision->old_value, true);
+                $entry->forgetTranslations($revision->key);
+                foreach($oldValueAsArray as $locale => $value) {
+                    $entry->setTranslation($revision->key, $locale, $value);
+                }
+                $entry->save();
+            }else{
+                // Update the revisioned field with the old value
+                $entry->update([$revision->key => $revision->old_value]);
+            }
 
-            // Update the revisioned field with the old value
-            $entry->update([$revision->key => $revision->old_value]);
-
-            $this->data['entry'] = $this->crud->getEntry($id);
+            $this->data['entry'] = $entry;
             $this->data['crud'] = $this->crud;
             $this->data['revisions'] = $this->crud->getRevisionsForEntry($id); // Reload revisions as they have changed
 

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -117,15 +117,15 @@ trait ReviseOperation
         } else {
             $entry = $this->crud->getEntryWithoutFakes($id);
             $revision = Revision::findOrFail($revisionId);
-           
-            if(method_exists($entry, 'isTranslatableAttribute') && $entry->isTranslatableAttribute($revision->key)) {
+
+            if (method_exists($entry, 'isTranslatableAttribute') && $entry->isTranslatableAttribute($revision->key)) {
                 $oldValueAsArray = json_decode($revision->old_value, true);
                 $entry->forgetTranslations($revision->key);
-                foreach($oldValueAsArray as $locale => $value) {
+                foreach ($oldValueAsArray as $locale => $value) {
                     $entry->setTranslation($revision->key, $locale, $value);
                 }
                 $entry->save();
-            }else{
+            } else {
                 // Update the revisioned field with the old value
                 $entry->update([$revision->key => $revision->old_value]);
             }

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -122,7 +122,7 @@ trait ReviseOperation
                 $oldValueAsArray = json_decode($revision->old_value, true);
                 $entry->forgetTranslation($revision->key, app()->getLocale());
                 $entry->setTranslation($revision->key, app()->getLocale(), $oldValueAsArray[app()->getLocale()] ?? null);
-                
+
                 $entry->save();
             } else {
                 // Update the revisioned field with the old value


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

RevisionOperation didn't take into account translatable attributes so it would attempt to save the whole translations inside a single translation key when restoring. Reported in: Laravel-Backpack/revise-operation#20

### AFTER - What is happening after this PR?

The translations are re-created from the old saved translations and manually assigned.


## HOW

### How did you achieve that, in technical terms?

Manually set back the translation when restoring the entry attribute

### Is it a breaking change or non-breaking change?

I don't think it's a breaking change, this was not properly working after all. 


### How can we test the before & after?

Save a value for a translatable attribute that is using revisions, try to restore that value. 
