### PR TITLE
prevents lazy loading of revision history

### DIFF
--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -43,6 +43,7 @@ trait ReviseOperation
 
         $this->crud->operation(['list', 'show'], function () {
             // add a button in the line stack
+            $this->crud->query->with('revisionHistory');
             $this->crud->addButton('line', 'revise', 'view', 'revise-operation::revise_button', 'end');
         });
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in #22 

### AFTER - What is happening after this PR?

We eager load the `revisionHistory`

### Is it a breaking change or non-breaking change?

No


### How can we test the before & after?

Add to service provider:
```php
use Illuminate\Database\Eloquent\Model;
 
public function boot()
{
    Model::preventLazyLoading(! $this->app->isProduction());
}
```
Try to load a table with revisions enabled.