### PR TITLE
Revision Class from config

### DIFF
--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -116,7 +116,8 @@ trait ReviseOperation
             abort(500, 'Can\'t restore revision without revision_id');
         } else {
             $entry = $this->crud->getEntryWithoutFakes($id);
-            $revision = Revision::findOrFail($revisionId);
+            $classString = is_string(config('revisionable.model')) && class_exists(config('revisionable.model')) ? config('revisionable.model') : Revision::class;
+            $revision = $classString::findOrFail($revisionId);
 
             // Update the revisioned field with the old value
             $entry->update([$revision->key => $revision->old_value]);

--- a/src/ReviseOperation.php
+++ b/src/ReviseOperation.php
@@ -116,8 +116,7 @@ trait ReviseOperation
             abort(500, 'Can\'t restore revision without revision_id');
         } else {
             $entry = $this->crud->getEntryWithoutFakes($id);
-            $classString = is_string(config('revisionable.model')) && class_exists(config('revisionable.model')) ? config('revisionable.model') : Revision::class;
-            $revision = $classString::findOrFail($revisionId);
+            $revision = \Venturecraft\Revisionable\Revisionable::newModel()->findOrFail($revisionId);
 
             // Update the revisioned field with the old value
             $entry->update([$revision->key => $revision->old_value]);


### PR DESCRIPTION
read revision class from config.

### BEFORE - What was wrong? What was happening before this PR?
https://github.com/VentureCraft/revisionable
original revisionable package support read eloquent model from config, but backpack revisionable operation doesn't support it.